### PR TITLE
Cache swagger requests + cleanup

### DIFF
--- a/services/account/package.json
+++ b/services/account/package.json
@@ -11,11 +11,12 @@
     "compression": "^1.0.3",
     "cors": "^2.5.2",
     "helmet": "^1.3.0",
+    "loopback": "^3.0.0",
     "loopback-boot": "^2.6.5",
-    "serve-favicon": "^2.0.1",
-    "strong-error-handler": "^1.0.1",
     "loopback-component-explorer": "^4.0.0",
-    "loopback": "^3.0.0"
+    "morgan": "^1.7.0",
+    "serve-favicon": "^2.0.1",
+    "strong-error-handler": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^2.13.1",

--- a/services/account/server/middleware.json
+++ b/services/account/server/middleware.json
@@ -1,6 +1,9 @@
 {
   "initial:before": {
-    "loopback#favicon": {}
+    "loopback#favicon": {},
+    "morgan": {
+      "params": ["dev"]
+    }
   },
   "initial": {
     "compression": {},

--- a/services/customer/package.json
+++ b/services/customer/package.json
@@ -11,11 +11,12 @@
     "compression": "^1.0.3",
     "cors": "^2.5.2",
     "helmet": "^1.3.0",
+    "loopback": "^3.0.0",
     "loopback-boot": "^2.6.5",
-    "serve-favicon": "^2.0.1",
-    "strong-error-handler": "^1.0.1",
     "loopback-component-explorer": "^4.0.0",
-    "loopback": "^3.0.0"
+    "morgan": "^1.7.0",
+    "serve-favicon": "^2.0.1",
+    "strong-error-handler": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^2.13.1",

--- a/services/customer/server/middleware.json
+++ b/services/customer/server/middleware.json
@@ -1,6 +1,9 @@
 {
   "initial:before": {
-    "loopback#favicon": {}
+    "loopback#favicon": {},
+    "morgan": {
+      "params": ["dev"]
+    }
   },
   "initial": {
     "compression": {},

--- a/services/facade/common/models/account-cache.js
+++ b/services/facade/common/models/account-cache.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(AccountCache) {
+
+};

--- a/services/facade/common/models/account-cache.json
+++ b/services/facade/common/models/account-cache.json
@@ -1,0 +1,9 @@
+{
+  "name": "AccountCache",
+  "base": "KeyValueModel",
+  "properties": {},
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": {}
+}

--- a/services/facade/common/models/customer-cache.js
+++ b/services/facade/common/models/customer-cache.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(CustomerCache) {
+
+};

--- a/services/facade/common/models/customer-cache.json
+++ b/services/facade/common/models/customer-cache.json
@@ -1,0 +1,9 @@
+{
+  "name": "CustomerCache",
+  "base": "KeyValueModel",
+  "properties": {},
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": {}
+}

--- a/services/facade/common/models/transaction-cache.js
+++ b/services/facade/common/models/transaction-cache.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(TransactionCache) {
+
+};

--- a/services/facade/common/models/transaction-cache.json
+++ b/services/facade/common/models/transaction-cache.json
@@ -1,0 +1,9 @@
+{
+  "name": "TransactionCache",
+  "base": "KeyValueModel",
+  "properties": {},
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": {}
+}

--- a/services/facade/package.json
+++ b/services/facade/package.json
@@ -15,7 +15,7 @@
     "loopback": "^3.0.0",
     "loopback-boot": "^2.6.5",
     "loopback-component-explorer": "^4.0.0",
-    "loopback-connector-swagger": "strongloop/loopback-connector-swagger#feature/cache-get-requests",
+    "loopback-connector-swagger": "^3.1.0",
     "morgan": "^1.7.0",
     "serve-favicon": "^2.0.1",
     "strong-error-handler": "^1.0.1"

--- a/services/facade/package.json
+++ b/services/facade/package.json
@@ -16,6 +16,7 @@
     "loopback-boot": "^2.6.5",
     "loopback-component-explorer": "^4.0.0",
     "loopback-connector-swagger": "strongloop/loopback-connector-swagger#feature/cache-get-requests",
+    "morgan": "^1.7.0",
     "serve-favicon": "^2.0.1",
     "strong-error-handler": "^1.0.1"
   },

--- a/services/facade/server/datasources.json
+++ b/services/facade/server/datasources.json
@@ -2,20 +2,36 @@
   "account": {
     "name": "account",
     "connector": "swagger",
-    "spec": "http://account/explorer/swagger.json"
+    "spec": "http://account/explorer/swagger.json",
+    "cache": {
+      "model": "AccountCache",
+      "ttl": 60000
+    }
   },
   "customer": {
     "name": "customer",
     "connector": "swagger",
-    "spec": "http://customer/explorer/swagger.json"
+    "spec": "http://customer/explorer/swagger.json",
+    "cache": {
+      "model": "CustomerCache",
+      "ttl": 60000
+    }
   },
   "transaction": {
     "name": "transaction",
     "connector": "swagger",
-    "spec": "http://transaction/explorer/swagger.json"
+    "spec": "http://transaction/explorer/swagger.json",
+    "cache": {
+      "model": "TransactionCache",
+      "ttl": 60000
+    }
   },
   "shared-cache": {
     "name": "shared-cache",
+    "connector": "kv-memory"
+  },
+  "private-cache": {
+    "name": "private-cache",
     "connector": "kv-memory"
   }
 }

--- a/services/facade/server/middleware.json
+++ b/services/facade/server/middleware.json
@@ -1,6 +1,9 @@
 {
   "initial:before": {
-    "loopback#favicon": {}
+    "loopback#favicon": {},
+    "morgan": {
+      "params": ["dev"]
+    }
   },
   "initial": {
     "compression": {},

--- a/services/facade/server/model-config.json
+++ b/services/facade/server/model-config.json
@@ -21,12 +21,24 @@
     "dataSource": "shared-cache",
     "public": false
   },
+  "AccountCache": {
+    "dataSource": "private-cache",
+    "public": false
+  },
   "Customer": {
     "dataSource": "customer",
     "public": false
   },
+  "CustomerCache": {
+    "dataSource": "private-cache",
+    "public": false
+  },
   "Transaction": {
     "dataSource": "transaction",
+    "public": false
+  },
+  "TransactionCache": {
+    "dataSource": "private-cache",
     "public": false
   }
 }

--- a/services/transaction/package.json
+++ b/services/transaction/package.json
@@ -11,11 +11,12 @@
     "compression": "^1.0.3",
     "cors": "^2.5.2",
     "helmet": "^1.3.0",
+    "loopback": "^3.0.0",
     "loopback-boot": "^2.6.5",
-    "serve-favicon": "^2.0.1",
-    "strong-error-handler": "^1.0.1",
     "loopback-component-explorer": "^4.0.0",
-    "loopback": "^3.0.0"
+    "morgan": "^1.7.0",
+    "serve-favicon": "^2.0.1",
+    "strong-error-handler": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^2.13.1",

--- a/services/transaction/server/middleware.json
+++ b/services/transaction/server/middleware.json
@@ -1,6 +1,9 @@
 {
   "initial:before": {
-    "loopback#favicon": {}
+    "loopback#favicon": {},
+    "morgan": {
+      "params": ["dev"]
+    }
   },
   "initial": {
     "compression": {},

--- a/test/acceptance/facade/account-summary.test.js
+++ b/test/acceptance/facade/account-summary.test.js
@@ -23,6 +23,6 @@ describe('facade - account summary', () => {
         expect(res.customer).to.be.an('object');
         expect(res.transactions).to.have.length(5);
       });
-    }).timeout(5000); // depends on delay set in microservice response
+    });
   });
 });

--- a/test/acceptance/facade/vitals.test.js
+++ b/test/acceptance/facade/vitals.test.js
@@ -13,11 +13,9 @@ describe('facade - vitals', () => {
       })
       .then(res => {
         expect(res.status).to.equal('healthy');
-        expect(res.latency).to.be.number();
         expect(res.dependencies).to.eql({
           account: {
             status: 'healthy',
-            latency: 1000,
             dependencies: {
               accountDB: {
                 status: 'healthy'
@@ -26,7 +24,6 @@ describe('facade - vitals', () => {
           },
           customer: {
             status: 'healthy',
-            latency: 1000,
             dependencies: {
               customerDB: {
                 status: 'healthy'
@@ -35,7 +32,6 @@ describe('facade - vitals', () => {
           },
           transaction: {
             status: 'healthy',
-            latency: 1000,
             dependencies: {
               transactionDB: {
                 status: 'healthy'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --recursive
+--timeout 15000


### PR DESCRIPTION
**Add "morgan" for logging HTTP traffic**

This way we can inspect when our Swagger-connector powered client Models are making a request and when a cached response is returned instead.

**Enable caching for Swagger connector models**

Use the recently implemented https://github.com/strongloop/loopback-connector-swagger/pull/27 to cache HTTP requests made by the Facade service. I picked 60s as TTL, feel free to change this value as needed.

**Fix failing acceptance tests**

`npm test` was failing for me, I fixed timeout settings and expected health-check response (no `latency` is reported on my machine).

cc @ritch @superkhau @deepakrkris 