### PR TITLE
Refactor facade services to use async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-subset": "^1.5.0",
     "debug": "^2.6.3",
     "dirty-chai": "^1.2.2",
     "mocha": "^3.2.0",

--- a/services/facade/Dockerfile
+++ b/services/facade/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9
+FROM node:7
 
 # Create app directory
 RUN mkdir -p /usr/src/facade

--- a/services/facade/common/models/account.js
+++ b/services/facade/common/models/account.js
@@ -1,69 +1,59 @@
 'use strict';
 
 const app = require('../../server/server');
+const Promise = require('bluebird');
 
 // NOTE: View `console.log` output in the docker-compose logs
 
 module.exports = function(Account) {
   function getAggregateAccountSummary(accountNumber) {
-    let accountSummary = {};
-    return Account.AccountSummary_findById({id: accountNumber}).get('obj')
-      .then(function (data) {
-        accountSummary = data;
-      })
-      .then(function () {
-        return Account.Account_findById({id: accountNumber}).get('obj');
-      })
-      .then(function (data) {
-        accountSummary.account = data;
-      })
-      .then(function () {
-        return app.models.Customer.findById(accountSummary.account.customerNumber);
-      })
-      .then(function (data) {
-        accountSummary.customer = data;
-      })
-      .then(function () {
-        return app.models.Transaction.find(accountNumber);
-      })
-      .then(function (data) {
-        accountSummary.transactions = data;
-        return accountSummary;
-      });
+    const {Transaction} = app.models;
+    return Promise.props({
+      account: Account.getSummary(accountNumber),
+      customer: Account.getCustomer(accountNumber),
+      transactions: Transaction.find(accountNumber),
+    });
   }
 
-  Account.getAccountSummary = function(accountNumber, cache) {
+  Account.getAccountSummary = async function(accountNumber, cache) {
     const Cache = app.models.Cache;
 
     // DEMO(ritch): explain why url + acctNum instead of just acctNum
     const key = '/api/Account/summary?accountNumber=' + accountNumber;
 
     console.log('checking the facade level cache');
-    return Cache.get(key).then(accountSummary => {
-      if (accountSummary && cache !== false) {
-        return Cache.ttl(key).then(ttl => {
-          console.log('cache hit, return cache data, ttl:', ttl);
-          accountSummary.cache = ttl;
-          return accountSummary;
-        });
-      }
+    let accountSummary = await Cache.get(key);
+    if (accountSummary && cache !== false) {
+      const ttl = await Cache.ttl(key);
+      console.log('cache hit, return cache data, ttl:', ttl);
+      accountSummary.cache = ttl;
+      return accountSummary;
+    }
 
-      console.log('cache miss, get data from microservice');
-      return getAggregateAccountSummary(accountNumber)
-        .then(accountSummary => {
-          // ttl should be short because some data changes often
-          // account aggressive infinite ttl at microservice level
-          // customer aggresive infinite ttl
-          // transaction non-aggressive very short ttl
-          console.log('update cache with returned data');
-          // DEMO(ritch): change to 60s after, explain why 60s to crowd
-          return Cache.set(key, accountSummary, {ttl: 60000}) // 10s for testing
-            .return(accountSummary);
-        });
-    });
+    console.log('cache miss, get data from microservice');
+    accountSummary = await getAggregateAccountSummary(accountNumber);
+    // ttl should be short because some data changes often
+    // account aggressive infinite ttl at microservice level
+    // customer aggresive infinite ttl
+    // transaction non-aggressive very short ttl
+    console.log('update cache with returned data');
+    // DEMO(ritch): change to 60s after, explain why 60s to crowd
+    await Cache.set(key, accountSummary, {ttl: 60000}); // 10s for testing
+
+    return accountSummary;
   };
 
   Account.getAccountByNumber = function(accountNumber) {
     return Account.Account_findById({id: accountNumber}).get('obj');
   };
+
+  Account.getSummary = function(accountNumber) {
+    return Account.AccountSummary_findById({id: accountNumber}).get('obj');
+  }
+
+  Account.getCustomer = async function(accountNumber) {
+    const {Customer} = app.models;
+    const data = await Account.getAccountByNumber(accountNumber);
+    return Customer.findById(data.customerNumber);
+  }
 };

--- a/test/acceptance/facade/account-summary.test.js
+++ b/test/acceptance/facade/account-summary.test.js
@@ -15,12 +15,19 @@ describe('facade - account summary', () => {
       })
       .then(res => {
         debug(res);
-        expect(res.accountNumber).to.equal(accountNumber);
         expect(res.account).to.eql({
           accountNumber: accountNumber,
-          customerNumber: '000343223',
+          avgBalance: 398.93,
+          balance: 85.84,
+          branch: 'Foster City',
+          minimumBalance: 10,
+          type: 'Checking',
         });
-        expect(res.customer).to.be.an('object');
+        expect(res.customer).to.containSubset({
+          customerNumber: '000343223',
+          firstName: 'Homer',
+          lastName: 'Simpson',
+        });
         expect(res.transactions).to.have.length(5);
       });
     });

--- a/test/support/expect.js
+++ b/test/support/expect.js
@@ -2,5 +2,6 @@ const chai = require('chai');
 const dirtyChai = require('dirty-chai');
 
 chai.use(dirtyChai);
+chai.use(require('chai-subset'));
 
 module.exports = chai.expect;


### PR DESCRIPTION
Also change the response format of `getAccountSummary` to return a simple object with three properties (`account`, `customer` and `transactions`).

@ritch @superkhau @deepakrkris 