### PR TITLE
Update docker-compose dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,21 +9,32 @@ services:
       - account
       - customer
       - transaction
+    depends_on:
+      - mongo
+      - account
+      - customer
+      - transaction
   customer:
     build: ./services/customer
     image: loopback-example-facade/customer-service
     ports:
       - "3001:80"
+    depends_on:
+      - mongo
   account:
     build: ./services/account
     image: loopback-example-facade/account-service
     ports:
       - "3002:80"
+    depends_on:
+      - mongo
   transaction:
     build: ./services/transaction
     image: loopback-example-facade/transaction
     ports:
       - "3003:80"
+    depends_on:
+      - mongo
   mongo:
     image: mongo
     volumes:


### PR DESCRIPTION
The mongo instance needs to be marked as a dependency and started first otherwise the facade service will fail with an erroneous error that makes it sound like there's a CORS configuration problem.

### Description
With this change I'm able to run the recommended docker-compose command to test the example project.

#### Related issues

- connect to #46 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
